### PR TITLE
# Mail 패스워드 분실 인증번호 발송 구현 / Mail 발송 로직 변경

### DIFF
--- a/src/main/java/org/example/bikers/domain/mail/controller/MailController.java
+++ b/src/main/java/org/example/bikers/domain/mail/controller/MailController.java
@@ -28,6 +28,14 @@ public class MailController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @PostMapping("/forget-password/verification-code")
+    public ResponseEntity<Void> sendVerificationCodeForPasswordForget(
+        @Valid @RequestBody MailGetEmailRequestDto requestDto)
+        throws MessagingException {
+        mailService.sendVerificationCodeForPasswordForget(requestDto.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
     @PostMapping("/verification")
     public ResponseEntity<Void> verify(
         @Valid @RequestBody MailGetVerifyEmailRequestDto requestDto) {

--- a/src/main/java/org/example/bikers/domain/member/service/MemberService.java
+++ b/src/main/java/org/example/bikers/domain/member/service/MemberService.java
@@ -8,9 +8,11 @@ import lombok.RequiredArgsConstructor;
 import org.example.bikers.domain.member.entity.Member;
 import org.example.bikers.domain.member.entity.MemberRole;
 import org.example.bikers.domain.member.entity.MemberStatus;
+import org.example.bikers.domain.member.entity.SignUpSource;
 import org.example.bikers.domain.member.repository.MemberRepository;
 import org.example.bikers.global.exception.customException.NotFoundException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -74,6 +76,18 @@ public class MemberService {
 
         getMember.promote();
         memberRepository.save(getMember);
+    }
+
+    @Transactional
+    public void validateByLocalUser(String email) {
+        Member getMember = memberRepository.findByEmail(email).orElseThrow(() ->
+            new NotFoundException(NO_SUCH_MEMBER));
+        if (getMember.getStatus().equals(MemberStatus.DELETE)) {
+            throw new NotFoundException(DELETED_MEMBER);
+        }
+        if (!getMember.getSignUpSource().equals(SignUpSource.LOCAL)) {
+            throw new DuplicateKeyException(getMember.getSignUpSource() + " 플랫폼으로 가입한 회원입니다.");
+        }
     }
 
     private Member findByMember(Long memberId) {


### PR DESCRIPTION
* 패스워드 분실시 이메일 인증 기능 구현
  - 기존 회원가입시 이메일 기능과는 별반 다를바 없지만, OAuth로 회원가입한 유저와 삭제된 유저는 이메일 인증을 할 수 없도록 제한을 두었다
* 메일 발송시기 변경
  - 메일은 이미 발송되면 Rollback이 어렵다. 현재 로직은 메일을 발송 후 Mail 객체를 DB에 저장하는데 Mail 객체를 저장시에 오류가 발생하면 메일은 이미 발송되고 발송된 인증번호와 메일주소를 입력해도 인증이 되지 않는 문제가 발생할 수 있다. 이러한 점을 고려하여 Mail 객체를 먼저 저장 뒤 정상적으로 저장되면 메일을 발송하도록 실행순위를 변경하였다